### PR TITLE
cjl - Add basic makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SOURCEDIR := src
+DISTDIR := dist
+SOURCES := $(shell find $(SOURCEDIR) -name '*.js')
+TRANSPILED := $(patsubst $(SOURCEDIR)/%, $(DISTDIR)/%, $(SOURCES))
+
+$(TRANSPILED): $(SOURCES)
+	./node_modules/.bin/babel $(SOURCEDIR) --out-dir $(DISTDIR)
+
+test: $(TRANSPILED)
+	./node_modules/.bin/mocha --reporter spec

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "An implementation of the ancient Chinese board board Go (Chinese: wéiqí, Korean: baduk, Japanese: igo)",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha --reporter spec",
-    "build": "babel src --out-dir dist"
+    "test": "make test",
+    "build": "make"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I found myself doing something like

    $ npm run build && npm test

a bit too frequently. Figured `make` was a good way to do this.