### PR TITLE
Implement Board.getIntersections with mutations and reduction

### DIFF
--- a/dist/lib/board.js
+++ b/dist/lib/board.js
@@ -136,9 +136,16 @@ var getGroup = function (stones, size, coords) {
     surrounding: surrounding });
 };
 
-var createEmptyGrid = function (size) {
-  return Immutable.Repeat(Immutable.Repeat(Constants.EMPTY, size).toList(), size).toList();
-};
+var createEmptyGrid = (function () {
+  var createGrid = function (size) {
+    return Immutable.Repeat(Immutable.Repeat(Constants.EMPTY, size).toList(), size).toList();
+  };
+
+  var cache = {};
+  return function (size) {
+    return cache[size] || (cache[size] = createGrid(size));
+  };
+})();
 
 var Board = (function () {
   function Board(size, stones) {
@@ -150,7 +157,6 @@ var Board = (function () {
 
     this.size = size;
     this.stones = stones;
-    this._empty_grid = createEmptyGrid(size);
   }
 
   _createClass(Board, {
@@ -188,7 +194,7 @@ var Board = (function () {
             return board.setIn([point.i, point.j], color);
           }, map);
         };
-        return this._empty_grid.withMutations(mergeStones);
+        return createEmptyGrid(this.size).withMutations(mergeStones);
       }
     },
     play: {

--- a/dist/lib/board.js
+++ b/dist/lib/board.js
@@ -136,6 +136,10 @@ var getGroup = function (stones, size, coords) {
     surrounding: surrounding });
 };
 
+var createEmptyGrid = function (size) {
+  return Immutable.Repeat(Immutable.Repeat(Constants.EMPTY, size).toList(), size).toList();
+};
+
 var Board = (function () {
   function Board(size, stones) {
     _classCallCheck(this, Board);
@@ -146,6 +150,7 @@ var Board = (function () {
 
     this.size = size;
     this.stones = stones;
+    this._empty_grid = createEmptyGrid(size);
   }
 
   _createClass(Board, {
@@ -178,12 +183,12 @@ var Board = (function () {
       value: function getIntersections() {
         var _this = this;
 
-        var range = Immutable.Range(0, this.size);
-        return range.map(function (i) {
-          return range.map(function (j) {
-            return getStone(_this.stones, new Point(i, j));
-          }).toList();
-        }).toList();
+        var mergeStones = function (map) {
+          return _this.stones.reduce(function (board, color, point) {
+            return board.setIn([point.i, point.j], color);
+          }, map);
+        };
+        return this._empty_grid.withMutations(mergeStones);
       }
     },
     play: {

--- a/src/lib/board.js
+++ b/src/lib/board.js
@@ -93,6 +93,13 @@ const getGroup = (stones, size, coords) => {
                      surrounding  : surrounding });
 };
 
+const createEmptyGrid = (size) =>
+  Immutable.Repeat(
+    Immutable.Repeat(Constants.EMPTY, size).toList(),
+    size
+  ).toList();
+
+
 class Board {
   constructor(size, stones) {
     if (typeof size === "undefined" || size < 0)
@@ -103,6 +110,7 @@ class Board {
 
     this.size = size;
     this.stones = stones;
+    this._empty_grid = createEmptyGrid(size);
   }
 
   getStone(coords) {
@@ -118,10 +126,12 @@ class Board {
   }
 
   getIntersections() {
-    const range = Immutable.Range(0, this.size);
-    return range.map(i =>
-      range.map(j => getStone(this.stones, new Point(i, j))).toList()
-    ).toList();
+    const mergeStones = map =>
+      this.stones.reduce(
+        (board, color, point) =>
+          board.setIn([point.i, point.j], color),
+        map);
+    return this._empty_grid.withMutations(mergeStones);
   }
 
   play(color, coords) {

--- a/src/lib/board.js
+++ b/src/lib/board.js
@@ -93,12 +93,16 @@ const getGroup = (stones, size, coords) => {
                      surrounding  : surrounding });
 };
 
-const createEmptyGrid = (size) =>
-  Immutable.Repeat(
-    Immutable.Repeat(Constants.EMPTY, size).toList(),
-    size
-  ).toList();
+const createEmptyGrid = (() => {
+  const createGrid = (size) =>
+    Immutable.Repeat(
+      Immutable.Repeat(Constants.EMPTY, size).toList(),
+      size
+    ).toList();
 
+  const cache = {};
+  return (size) => cache[size] || (cache[size] = createGrid(size));
+})();
 
 class Board {
   constructor(size, stones) {
@@ -110,7 +114,6 @@ class Board {
 
     this.size = size;
     this.stones = stones;
-    this._empty_grid = createEmptyGrid(size);
   }
 
   getStone(coords) {
@@ -131,7 +134,7 @@ class Board {
         (board, color, point) =>
           board.setIn([point.i, point.j], color),
         map);
-    return this._empty_grid.withMutations(mergeStones);
+    return createEmptyGrid(this.size).withMutations(mergeStones);
   }
 
   play(color, coords) {


### PR DESCRIPTION
Closes #22 

getIntersections used to be constant in the square of the board size. It's now linear in the number of stones on board. Uses Immutable's mutative API to efficiently produce a `reduce`d grid with all of the stones in place.